### PR TITLE
Fixed Broken Link to Red Teaming Paper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository provides access to:
 1. Human preference data about helpfulness and harmlessness from [Training a Helpful and Harmless Assistant with Reinforcement Learning from Human Feedback](https://arxiv.org/abs/2204.05862)
-2. Human-generated red teaming data from [Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned](https://www.anthropic.com/red_teaming.pdf).
+2. Human-generated red teaming data from [Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned](https://www.anthropic.com/index/red-teaming-language-models-to-reduce-harms-methods-scaling-behaviors-and-lessons-learned).
 
 Each of these datasets are described further below. 
 
@@ -20,7 +20,7 @@ Details about the data collection process and crowdworker population can be foun
 
 ## Red teaming data
 
-The data are described in the paper: [Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned](https://www.anthropic.com/red_teaming.pdf). If you find the data useful, please cite the paper.
+The data are described in the paper: [Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned](https://www.anthropic.com/index/red-teaming-language-models-to-reduce-harms-methods-scaling-behaviors-and-lessons-learned). If you find the data useful, please cite the paper.
 
 Details about the data and data collection procedures can be found in the Datasheet in the appendix of the paper. 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository provides access to:
 1. Human preference data about helpfulness and harmlessness from [Training a Helpful and Harmless Assistant with Reinforcement Learning from Human Feedback](https://arxiv.org/abs/2204.05862)
-2. Human-generated red teaming data from [Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned](https://www.anthropic.com/index/red-teaming-language-models-to-reduce-harms-methods-scaling-behaviors-and-lessons-learned).
+2. Human-generated red teaming data from [Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned](https://arxiv.org/abs/2209.07858).
 
 Each of these datasets are described further below. 
 
@@ -20,7 +20,7 @@ Details about the data collection process and crowdworker population can be foun
 
 ## Red teaming data
 
-The data are described in the paper: [Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned](https://www.anthropic.com/index/red-teaming-language-models-to-reduce-harms-methods-scaling-behaviors-and-lessons-learned). If you find the data useful, please cite the paper.
+The data are described in the paper: [Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned](https://arxiv.org/abs/2209.07858). If you find the data useful, please cite the paper.
 
 Details about the data and data collection procedures can be found in the Datasheet in the appendix of the paper. 
 


### PR DESCRIPTION
The correct link to the Red teaming paper linked in the README 